### PR TITLE
inconsistency around model= argument default

### DIFF
--- a/docs/reference/na_kalman.html
+++ b/docs/reference/na_kalman.html
@@ -158,9 +158,9 @@ object in which missing values shall be replaced</p></td>
 (on which KalmanSmooth is performed) can be chosen. Accepts the following input:</p>
 <ul>
 <li><p>"auto.arima" - For using the state space representation of
-arima model (using <a href='https://pkg.robjhyndman.com/forecast/reference/auto.arima.html'>auto.arima</a>) (default choice)</p></li>
+arima model (using <a href='https://pkg.robjhyndman.com/forecast/reference/auto.arima.html'>auto.arima</a>) </p></li>
 <li><p>"StructTS" - For using a structural model fitted by maximum
-likelihood (using <a href='https://rdrr.io/r/stats/StructTS.html'>StructTS</a>)</p></li>
+likelihood (using <a href='https://rdrr.io/r/stats/StructTS.html'>StructTS</a>) (default choice) </p></li>
 </ul>
 
 <p>For both auto.arima and StructTS additional parameters for model building can


### PR DESCRIPTION
model argument default seems to be model = "StrucTS", but argument description indicated auto.arima as default. I moved "(dafault choice)" from auto.arima to StructTS description.